### PR TITLE
[#2] Fixed an error in class export of Twig_SimpleFunction.

### DIFF
--- a/Twig/StringExtension.php
+++ b/Twig/StringExtension.php
@@ -13,6 +13,7 @@
 namespace BFOS\TwigExtensionsBundle\Twig;
 
 use Twig_SimpleFilter;
+use Twig_SimpleFunction;
 use BFOS\TwigExtensionsBundle\Utils\StringUtils;
 
 class StringExtension extends \Twig_Extension
@@ -74,6 +75,4 @@ class StringExtension extends \Twig_Extension
     {
         return StringUtils::endsWith($haystack, $needle);
     }
-
-
 }


### PR DESCRIPTION
This fixes an error introduced in https://github.com/BrazilianFriendsOfSymfony/BFOSTwigExtensionsBundle/pull/3.

Ping @ribeiropaulor